### PR TITLE
Docusaurus (FIX)

### DIFF
--- a/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-Albramvar1.md
+++ b/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-Albramvar1.md
@@ -1,6 +1,6 @@
 # Acuerdo de Participación en el Programa de Usuarios Piloto de EventBride - Alba Ramos Vargas
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-Felsolagu.md
+++ b/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-Felsolagu.md
@@ -1,6 +1,6 @@
 # Acuerdo de Participación en el Programa de Usuarios Piloto de EventBride - Felipe Solís Agudo
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-hugborang.md
+++ b/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-hugborang.md
@@ -1,6 +1,6 @@
 # Acuerdo de Participación en el Programa de Usuarios Piloto de EventBride - Hugo Borrego Ángulo
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-ramvergar.md
+++ b/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement-ramvergar.md
@@ -1,6 +1,6 @@
 # Acuerdo de Participación en el Programa de Usuarios Piloto de EventBride - Ramón Vergara Garrido
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement.md
+++ b/eventbride/docs/S2/Commitment Agreement usuarios piloto/pilotUsersCommitmentAgreement.md
@@ -1,6 +1,6 @@
 # Acuerdo de Participación en el Programa de Usuarios Piloto de EventBride - Curso 2024-2025
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 [Conversación de chatgpt usada en el desarrollo de este documento](https://chatgpt.com/g/g-p-6768021d7dcc8191b0d9ff3e7d086595-daniel/c/67c5b514-0e60-8008-8764-70efc40ab355 )
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-adrcabmar-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-adrcabmar-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-andpizcer-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-andpizcer-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-antmonlop4-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-antmonlop4-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-danbenhid-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-danbenhid-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-davgodfer-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-davgodfer-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-ferdehur-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-ferdehur-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-fraavicar1-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-fraavicar1-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-gonnavrem-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-gonnavrem-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-hecnoggon-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-hecnoggon-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-ignblabla-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-ignblabla-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-lortorlan1-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-lortorlan1-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-manpervel2-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-manpervel2-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-marcartal1-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-marcartal1-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-mighersan1-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-mighersan1-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-natolmvil-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-natolmvil-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-pabcascom-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-pabcascom-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement-serponlop-v5.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement-serponlop-v5.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Commitment agreement/commitmentAgreement.md
+++ b/eventbride/docs/S2/Commitment agreement/commitmentAgreement.md
@@ -1,6 +1,6 @@
 # Commitment Agreement v5
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/KBReport.md
+++ b/eventbride/docs/S2/KBReport.md
@@ -1,6 +1,6 @@
 # KB Report
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/Problems/problems.md
+++ b/eventbride/docs/S2/Problems/problems.md
@@ -1,6 +1,6 @@
 # Problemas encontrados
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../../img/Eventbride.png"></img></center>
+<center>![Logo](../../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/appMonetization.md
+++ b/eventbride/docs/S2/appMonetization.md
@@ -1,6 +1,6 @@
 # Monetización de la aplicación
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 
@@ -133,7 +133,7 @@ Por último, los proveedores tendrán un número limitado de 3 ofertas. Para muc
 
 Si el proveedor está satisfecho con la aplicación querrá tener un mayor número de ofertas a causa del crecimiento de su negocio y será susceptible al pago de una membresía premium que permitirá a esta poner ofertas ilimitadas. Además se le posicionará mejor en la aplicación. Este plan premium costará 50€ al mes.
 
-[Ver Excel Ganancias.xlsx](https://uses0-my.sharepoint.com/:x:/g/personal/danbenhid_alum_us_es/EUwnInhun7lNl22ZkGuyxnkBaTPWlwnXklO7hOZMDIzGLw?e=PGd0Ka)
+[Ver Excel[ Ganancias.xlsx\] ](https://uses0-my.sharepoint.com/:x:/g/personal/danbenhid_alum_us_es/EUwnInhun7lNl22ZkGuyxnkBaTPWlwnXklO7hOZMDIzGLw?e=PGd0Ka)
 
 
 Con este sistema, teniendo en cuenta sólo bodas, para amortizar la inversión inicial sólo necesitaríamos que se produjeran entre 42 a 63 pagos dependiendo de lo caras que sean las bodas. Viendo el volumen de bodas que se producen al año en Sevilla, es una cifra realista.
@@ -160,15 +160,15 @@ Teniendo en cuenta estos parametros, se podría estimar que el costo a corto pla
 
 A continuación haremos una estimación de los posibles beneficios. Para ello, tendré en cuenta las estimaciones hechas por los compañeros del costo de celebrar una boda[1], una comunión[2] y un bautizo[3]:
 
-<center><img src="../../img/costo_estimado_boda.png"></img></center>
+<center>![](../img/costo_estimado_boda.png)</center>
 Imagen 1. Costo estimado de una boda
 
 
-<center><img src="../../img/costo_estimado_comunion.png"></img></center>
+<center>![](../img/costo_estimado_comunion.png)</center>
 Imagen 2. Costo estimado de una comunión
 
 
-<center><img src="../../img/costo_estimado_bautizo.png"></img></center>
+<center>![](../img/costo_estimado_bautizo.png)</center>
 Imagen 3. Costo estimado de un bautizo
 
 

--- a/eventbride/docs/S2/changelogDoc.md
+++ b/eventbride/docs/S2/changelogDoc.md
@@ -1,6 +1,6 @@
 # Changelog
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/conductCode.md
+++ b/eventbride/docs/S2/conductCode.md
@@ -1,6 +1,6 @@
 # Conduct Code
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/costsAnalysis.md
+++ b/eventbride/docs/S2/costsAnalysis.md
@@ -1,6 +1,6 @@
 # Análisis de costes
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/customerAgreement.md
+++ b/eventbride/docs/S2/customerAgreement.md
@@ -1,6 +1,6 @@
 # Customer Agreement
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/halfSprintRetrospective.md
+++ b/eventbride/docs/S2/halfSprintRetrospective.md
@@ -1,6 +1,6 @@
 # RETROSPECTIVA MITAD SPRINT 2
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/legalImplications.md
+++ b/eventbride/docs/S2/legalImplications.md
@@ -1,6 +1,6 @@
 # Implicaciones legales
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/marketingAds.md
+++ b/eventbride/docs/S2/marketingAds.md
@@ -1,6 +1,6 @@
 # Anuncios publicitarios
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/metrics.md
+++ b/eventbride/docs/S2/metrics.md
@@ -1,7 +1,6 @@
 # Especificaciones métricas
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/performanceEvaluation.md
+++ b/eventbride/docs/S2/performanceEvaluation.md
@@ -1,6 +1,6 @@
 # Performance Evaluation
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png" alt="Event Image"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 
@@ -604,6 +604,3 @@ En este Sprint he desarrollado en su mayoria tareas de codigo: Primeramente, jun
 ## Bibliografía
 
 Intencionalmente en blanco.
-
-
-

--- a/eventbride/docs/S2/pilotUsers.md
+++ b/eventbride/docs/S2/pilotUsers.md
@@ -1,7 +1,6 @@
 # Análisis de viabilidad y gestión de usuarios pilotos
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/pilotUsersPerformanceEvaluation.md
+++ b/eventbride/docs/S2/pilotUsersPerformanceEvaluation.md
@@ -1,6 +1,6 @@
 # Evaluación del Rendimiento de los Usuarios Piloto
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: EventBride
 

--- a/eventbride/docs/S2/quantitativeAndQualitativeAnalysisOfTheTeam.md
+++ b/eventbride/docs/S2/quantitativeAndQualitativeAnalysisOfTheTeam.md
@@ -1,6 +1,6 @@
 # Análisis Cuantitativo y Cualitativo del Equipo
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/requirements.md
+++ b/eventbride/docs/S2/requirements.md
@@ -1,6 +1,6 @@
 # Requisitos
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/revision.md
+++ b/eventbride/docs/S2/revision.md
@@ -1,6 +1,6 @@
 # Manual de usuario
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 
@@ -129,131 +129,131 @@ Este manual de usuario le guiará a través de las funcionalidades principales d
 
 Para comenzar, al iniciar la aplicación se muestra un formulario de inicio de sesión el cual hay que completar para poder acceder a las funcionalidades de esta.
 
-<center><img src="../../img/login.png"></img></center>
+<center>![login](../img/login.png)</center>
 
 En caso de no tener cuenta, se puede acceder a la pestaña de registrarse y completar el formulario correspondiente para poder crearse una cuenta pudiendo elegir el tipo de usuario que desea ser (cliente o proveedor).
 
-<center><img src="../../img/register.png"></img></center>
+<center>![register](../img/register.png)</center>
 
 Para cualquier tipo de usuario se puede ver una página de inicio que es la página siguiente donde nos presentamos, hay una breve descripción sobre lo que hacemos y como trabajamos, hay una barra de navegación en la parte superior de la pantalla donde se puede viajar a todas las funcionalidades de Eventbride y por último se pueden acceder a los chats abiertos en el botón verde de abajo derecha.
 
-<center><img src="../../img/inicio.png"></img></center>
+<center>![inicio](../img/inicio.png)</center>
 
 También para cualquier usuario, si se accede a los chats se muestra al inicio todos los chats abiertos con el último mensaje enviado de la conversación.
 
-<center><img src="../../img/chats.png"></img></center>
+<center>![chats](../img/chats.png)</center>
 
 Y si se accede a un chat en especifico, se podrá enviar mensajes escribiendolos y enviandolos, similar a Whatsapp.
 
-<center><img src="../../img/chatprivado.png"></img></center>
+<center>![chatprivado](../img/chatprivado.png)</center>
 
 Si iniciamos sesión con un usuario **cliente**, y accedemos a la sección de mis servicios, se pueden observar los servicios pertenecientes al usuario y sus respectivos datos.
 
-<center><img src="../../img/miseventos.png"></img></center>
+<center>![miseventos](../img/miseventos.png)</center>
 
 Se puede entrar en detalles de los eventos para poder leer toda la información de los mismos, también se puede borrar el evento que se seleccione y por último se puede realizar el pago mediante PayPal o tarjeta de crédito/débito.
 
-<center><img src="../../img/detalleseventos.png"></img></center>
+<center>![detalleseventos](../img/detalleseventos.png)</center>
 
 Si desea pagar los servicios individualmente, también puede hacerlo accediendo a la pestaña de pagar reserva que tiene cada servicio y se puede pagar por los mismos medios mencionados anteriormente, por PayPal y tarjeta de crédito/débito.
 
-<center><img src="../../img/pagoservicio.png"></img></center>
+<center>![pagoservicio](../img/pagoservicio.png)</center>
 
 También se puede meter en la sección de crear evento donde se muestra un formulario a completar y se crea el evento. 
 
-<center><img src="../../img/crearevento.png"></img></center>
+<center>![crearevento](../img/crearevento.png)</center>
 
 Se puede acceder a la pestaña de los recintos donde se pueden ver los recintos disponibles, su localización en el mapa, los detalles de cada recinto y la posibilidad de chatear con el dueño del recinto.
 
-<center><img src="../../img/recintosdisponibles.png"></img></center>
+<center>![recintosdisponibles](../img/recintosdisponibles.png)</center>
 
 Si se desea añadir un recinto a uno de los eventos que tengas ya creado, se debe rellenar un formulario indicando el evento al que quieres asignar dicho recinto y completar la hora de inicio y final de la reserva del sitio.
 
-<center><img src="../../img/añadirrecinto.png"></img></center>
+<center>![añadirrecinto](../img/añadirrecinto.png)</center>
 
 También se pueden añadir diferentes servicios como pueden ser de catering, entretenimiento y decoración, para ello accede a la pestaña de otros servicios y podrás ver los diferentes servicios con sus detalles y la posibilidad de chatear con el dueño del servicio.
 
-<center><img src="../../img/otrosservicios.png"></img></center>
+<center>![otrosservicios](../img/otrosservicios.png)</center>
 
 Si se desea añadir un servicio a uno de los eventos que tengas ya creado, se debe rellenar un formulario indicando el evento al que quieres asignar dicho servicio y completar la hora de inicio y final de la reserva del sitio.
 
-<center><img src="../../img/añadirservicio.png"></img></center>
+<center>![añadirservicio](../img/añadirservicio.png)</center>
 
 Si se accede a la pestaña de invitaciones, se verán todos tus eventos y la opción de editar los invitados.
 
-<center><img src="../../img/invitaciones.png"></img></center>
+<center>![invitaciones](../img/invitaciones.png)</center>
 
 Si se desea mirar los invitados de un evento y la posibilidad de añadir más, se puede acceder a la vista de editar invitados y se mostrarán los invitados actuales y la posibilidad de invitar más.
 
-<center><img src="../../img/invitacionesespecificas.png"></img></center>
+<center>![invitacionesespecificas](../img/invitacionesespecificas.png)</center>
 
 Al querer crear una invitación solo hay que rellenar un formulario en el que se debe especificar cuantos invitados tienen permiso para ir al evento con esa invitacón. Cuando se crea la invitación, se genera un link que se copia automaticamente al portapapeles el cual se deberá compartir con la persona que se desea invitar
 
-<center><img src="../../img/crearinvitacion.png"></img></center>
+<center>![crearinvitacion](../img/crearinvitacion.png)</center>
 
 Esta pestaña es la que verá la persona invitada cuando se meta en el link que le pasa el anfitrión de la boda. En esta pestaña se tiene que cumplimentar el formulario para poder confirmar tu asistencia a la boda.
 
-<center><img src="../../img/aceptarinvitacion.png"></img></center>
+<center>![aceptarinvitacion](../img/aceptarinvitacion.png)</center>
 
 También se puede acceder a la pestaña de detalles de perfil donde se muestran todos los datos y se da la posibilidad de editarlos o cerrar sesión.
 
-<center><img src="../../img/detallesperfil.png"></img></center>
+<center>![detallesperfil](../img/detallesperfil.png)</center>
 
 Si se desea actualizar los datos del perfil, se accede a la pestaña correspondiente, se modifican con un formulario simple y se le da a guardar.
 
-<center><img src="../../img/editarperfil.png"></img></center>
+<center>![editarperfil](../img/editarperfil.png)</center>
 
 Si iniciamos sesión con un usuario **proveedor**, se muestra la misma página inicial que los usuarios clientes pero se muestra el plan de pago al que pertenece y las funcionalidades correspondientes.
 
-<center><img src="../../img/inicioproveedor.png"></img></center>
+<center>![inicioproveedor](../img/inicioproveedor.png)</center>
 
 Si se accede a la pestaña de mis servicios, se muestran los servicios pertenecientes al proveedor pudiéndose editar y crear nuevos servicios en la misma sección.
 
-<center><img src="../../img/misservicios.png"></img></center>
+<center>![misservicios](../img/misservicios.png)</center>
 
 Dentro de editar un servicio, se muestra un formulario a modificar si se desea cambiar algún atributo del servicio.
 
-<center><img src="../../img/editarservicio.png"></img></center>
+<center>![editarservicio](../img/editarservicio.png)</center>
 
 Al crear un servicio, se muestra el formulario correspondiente (depende del tipo de servicio escogido) a completar.
 
-<center><img src="../../img/crearservicio.png"></img></center>
+<center>![crearservicio](../img/crearservicio.png)</center>
 
 En la pestaña de solicitudes se mostrarán las solicitudes pendientes que le queda al proveedor por aceptar o cancelar según su criterio. En el caso de haber solicitudes, se mostrarán todos los datos importantes de la misma y los botones de aceptar o cancelar.
 
-<center><img src="../../img/solicitudes.png"></img></center>
+<center>![solicitudes](../img/solicitudes.png)</center>
 
 La pestaña de editar perfil es la misma que la del usuario cliente añadiéndose un botón para actualizar el plan de pago.
 
-<center><img src="../../img/editarperfilproveedor.png"></img></center>
+<center>![editarperfilproveedor](../img/editarperfilproveedor.png)</center>
 
 Si se desea actualizar al plan premium, se puede realizar indicando el número de meses que se desea y se puede pagar con tarjeta o con PayPal.
 
-<center><img src="../../img/contratarpremium.png"></img></center>
+<center>![contratarpremium](../img/contratarpremium.png)</center>
 
 Si iniciamos sesión con un usuario **admin**, se muestra la misma página inicial que los usuarios clientes pero se muestran las funcionalidades correspondientes al administrador.
 
-<center><img src="../../img/inicioadmin.png"></img></center>
+<center>![inicioadmin](../img/inicioadmin.png)</center>
 
 Si accedemos a administrar servicios, se muestran todos los servicios del sistema dando la opción de editar y eliminar. 
 
-<center><img src="../../img/administrarservicios.png"></img></center>
+<center>![administrarservicios](../img/administrarservicios.png)</center>
 
 Si accedemos a la sección de editar, se nos muestra el formulario a rellenar.
 
-<center><img src="../../img/admineditarservicio.png"></img></center>
+<center>![admineditarservicio](../img/admineditarservicio.png)</center>
 
 La sección de administrar eventos funciona de la misma manera que la anterior mencionada (administrar servicios).
 
-<center><img src="../../img/administrareventos.png"></img></center>
+<center>![administrareventos](../img/administrareventos.png)</center>
 
 Si accedemos a la sección de editar, se nos muestra el formulario a rellenar.
 
-<center><img src="../../img/admineditarevento.png"></img></center>
+<center>![admineditarevento](../img/admineditarevento.png)</center>
 
 Y por último, si accedemos a la sección de administrar usuarios, se encuentran todos los usuarios del sistema devolviéndolos directamente en forma de formulario y si se desea editar se modifica dicho formulario y se pulsa el botón de editar. También se pueden eliminar del sistema.
 
-<center><img src="../../img/administrarusuarios.png"></img></center>
+<center>![administrarusuarios](../img/administrarusuarios.png)</center>
 
 <div id='id5'></div>
 

--- a/eventbride/docs/S2/rewards.md
+++ b/eventbride/docs/S2/rewards.md
@@ -1,6 +1,6 @@
 # Recompensas
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/scalability.md
+++ b/eventbride/docs/S2/scalability.md
@@ -1,6 +1,6 @@
 # Explicación de la App y Escalabilidad
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/sprintPlanning.md
+++ b/eventbride/docs/S2/sprintPlanning.md
@@ -1,6 +1,6 @@
 # Sprint planning
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/sprintRetrospective.md
+++ b/eventbride/docs/S2/sprintRetrospective.md
@@ -1,6 +1,6 @@
 # Retrospectiva del Sprint 2
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="https://iili.io/3BcQ3YJ.md.png" alt="Event Image"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 

--- a/eventbride/docs/S2/tasksRevision.md
+++ b/eventbride/docs/S2/tasksRevision.md
@@ -1,6 +1,6 @@
 # Revisión de Tareas
 ## Ingeniería del Software y Práctica Profesional (ISPP)
-<center><img src="../../img/Eventbride.png"></img></center>
+<center>![Logo](../img/Eventbride.png)</center>
 
 ### Grupo 3: Eventbride
 


### PR DESCRIPTION
Standardize image syntax across all markdown files by replacing `<img>` tags with markdown image syntax `![alt](path)`. This improves consistency and readability in the documentation.